### PR TITLE
fix: python error for pwritev2 symbol not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # AWS CLI v2
 ARG AWS_CLI_VERSION=2.17.7
-ARG ALPINE_VERSION=3.20
+ARG ALPINE_VERSION=3.19
 
 # To fetch the right alpine version use:
 # docker run --rm --entrypoint ash eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:${GOOGLE_CLOUD_CLI_IMAGE_TAG} -c 'cat /etc/issue'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # You can find the list of the available image tags here:
 # https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/EU/google-cloud-cli
 
-GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 489.0.0-alpine
+GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 490.0.0-alpine
 IMAGE_NAME ?= sparkfabrik/cloud-tools
 IMAGE_TAG ?= latest
 


### PR DESCRIPTION
### **User description**
Using the right alpine version fix the following error:

```bash
[61] Error loading Python lib '/usr/local/aws-cli/v2/2.17.7/dist/libpython3.11.so.1.0': dlopen: Error relocating /usr/local/aws-cli/v2/2.17.7/dist/libpython3.11.so.1.0: pwritev2: symbol not found
```

The issue is tracked [here](https://github.com/docker-library/python/issues/927).


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed Python error related to the `pwritev2` symbol not being found by downgrading the Alpine version in the Dockerfile from 3.20 to 3.19.
- Updated the Google Cloud CLI image tag in the Makefile from 489.0.0-alpine to 490.0.0-alpine.
- These changes aim to resolve the issue with loading the Python library in the AWS CLI container.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Downgrade Alpine version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

- Changed ALPINE_VERSION from 3.20 to 3.19



</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/40/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update Google Cloud CLI version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Updated GOOGLE_CLOUD_CLI_IMAGE_TAG from 489.0.0-alpine to <br>490.0.0-alpine<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/40/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

