### PR TITLE
feat: upgrade AWS CLI to 2.17.44 and gcloud to 491.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # AWS CLI v2
-ARG AWS_CLI_VERSION=2.17.7
+ARG AWS_CLI_VERSION=2.17.44
 ARG ALPINE_VERSION=3.19
 
 # To fetch the right alpine version use:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # You can find the list of the available image tags here:
 # https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/EU/google-cloud-cli
 
-GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 490.0.0-alpine
+GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 491.0.0-alpine
 IMAGE_NAME ?= sparkfabrik/cloud-tools
 IMAGE_TAG ?= latest
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded AWS CLI to version 2.17.44 in the Dockerfile
- Updated Google Cloud CLI to version 491.0.0-alpine in the Makefile
- These updates ensure the project is using the latest versions of both CLI tools, potentially including bug fixes, new features, and security improvements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Upgrade AWS CLI version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

- Upgraded AWS CLI version from 2.17.7 to 2.17.44


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/41/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update Google Cloud CLI version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Updated Google Cloud CLI image tag from 490.0.0-alpine to <br>491.0.0-alpine


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/41/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

