### PR TITLE
fix: print-basic-auth now supports secrets with namespace declared in annotation

### DIFF
--- a/scripts/bash_functions.sh
+++ b/scripts/bash_functions.sh
@@ -23,6 +23,8 @@ function print-basic-auth() {
       echo "No auth secret found for ingress ${INGRESS} (${FIRST_HOST})"
       continue
     fi
+    # Remove the prefix from the secret name, if it is present
+    SECRET="$(echo "${SECRET}" | cut -d"/" -f1)"
     USERNAME=$(kubectl --namespace "${CURRENT_NAMESPACE}" get secret "${SECRET}" -o jsonpath="{.data.username}" | base64 -d)
     PASSWORD=$(kubectl --namespace "${CURRENT_NAMESPACE}" get secret "${SECRET}" -o jsonpath="{.data.password}" | base64 -d)
     if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed issue where `print-basic-auth` function couldn't handle secrets with namespace declared in annotation
- Added logic to remove prefix from secret name using `cut` command
- Improves compatibility and flexibility of the authentication process
- Ensures correct retrieval of username and password from Kubernetes secrets


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bash_functions.sh</strong><dd><code>Support for secrets with namespace in annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/bash_functions.sh

<li>Added functionality to remove prefix from secret name using <code>cut</code> <br>command<br> <li> Ensures compatibility with secrets that have namespace declared in <br>annotation


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/42/files#diff-25c8806dd7bd2d4911321d2802e58bed4253ec3ba50a4c9ea6f40f7de69db56d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

