### PR TITLE
feat: upgrade gcloud cli version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # You can find the list of the available image tags here:
 # https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/EU/google-cloud-cli
 
-GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 491.0.0-alpine
+GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 492.0.0-alpine
 IMAGE_NAME ?= sparkfabrik/cloud-tools
 IMAGE_TAG ?= latest
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded the Google Cloud CLI version from 491.0.0-alpine to 492.0.0-alpine in the Makefile.
- This update ensures the project is using the latest version of the Google Cloud CLI, which may include bug fixes, new features, or performance improvements.
- The change affects the `cloud-tools` target in the Makefile, which is responsible for building the Docker image.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Upgrade Google Cloud CLI version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Updated the <code>GOOGLE_CLOUD_CLI_IMAGE_TAG</code> from 491.0.0-alpine to <br>492.0.0-alpine<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/43/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

