### PR TITLE
platform/#3515: add DNS endpoint check to get the Kubeconfig for GKE cluster

### DIFF
--- a/scripts/docker-entrypoint.d/010-configure-cluster
+++ b/scripts/docker-entrypoint.d/010-configure-cluster
@@ -70,7 +70,17 @@ if [ "${CLUSTER_TYPE}" = "GKE" ]; then
           export CLUSTER_NAME
           export KUBECONFIG="/tmp/${CLUSTER_NAME}_kubeconfig"
           echo "export CLUSTER_NAME=\"${CLUSTER_NAME}\"" >>"${ADDITIONAL_ENV_FILE}"
-          gcloud container clusters get-credentials "${CLUSTER_NAME}" --project "${GCP_PROJECT}" --zone "${CLUSTER_LOCATION}"
+
+          # Verify if the cluster use DNS endpoint to connect to the control plane
+          # and set the DNS_ENDPOINT_OPT variable to use it
+          DNS_ENDPOINT_OPT=""
+          CLUSTER_INFO=$(gcloud container clusters describe "${CLUSTER_NAME}" --project "${CLOUDSDK_CORE_PROJECT}" --zone "${CLUSTER_LOCATION}" --format=json)
+          CONTROL_PLANE_ALLOW_EXTERNAL_DNS=$(echo "${CLUSTER_INFO}" | jq -r '.controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic')
+          if [ "${CONTROL_PLANE_ALLOW_EXTERNAL_DNS}" = "true" ]; then
+            DNS_ENDPOINT_OPT="--dns-endpoint"
+          fi
+
+          gcloud container clusters get-credentials "${CLUSTER_NAME}" --project "${GCP_PROJECT}" --zone "${CLUSTER_LOCATION}" ${DNS_ENDPOINT_OPT}
           EXIT_CONF_KUBECONFIG=$?
           if [ "${EXIT_CONF_KUBECONFIG}" -eq 0 ]; then
             readSecret


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add DNS endpoint check for GKE clusters

- Use DNS endpoint for control plane connection when available


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>010-configure-cluster</strong><dd><code>Add DNS endpoint support for GKE cluster authentication</code>&nbsp; &nbsp; </dd></summary>
<hr>

scripts/docker-entrypoint.d/010-configure-cluster

<li>Added logic to check if GKE cluster uses DNS endpoint for control <br>plane access<br> <li> Retrieves cluster information to check <br><code>controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic</code><br> <li> Sets <code>--dns-endpoint</code> option when external DNS traffic is allowed<br> <li> Updates <code>gcloud container clusters get-credentials</code> command with DNS <br>endpoint option


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/47/files#diff-0f8693c02845e871e428f2788ecd4f88075a4f301fefcc05ff2f4cf3881334ed">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>