### PR TITLE
fix: Rename variable CLOUDSDK_CORE_PROJECT to GCP_PROJECT

### DIFF
--- a/scripts/docker-entrypoint.d/010-configure-cluster
+++ b/scripts/docker-entrypoint.d/010-configure-cluster
@@ -74,7 +74,7 @@ if [ "${CLUSTER_TYPE}" = "GKE" ]; then
           # Verify if the cluster use DNS endpoint to connect to the control plane
           # and set the DNS_ENDPOINT_OPT variable to use it
           DNS_ENDPOINT_OPT=""
-          CLUSTER_INFO=$(gcloud container clusters describe "${CLUSTER_NAME}" --project "${CLOUDSDK_CORE_PROJECT}" --zone "${CLUSTER_LOCATION}" --format=json)
+          CLUSTER_INFO=$(gcloud container clusters describe "${CLUSTER_NAME}" --project "${GCP_PROJECT}" --zone "${CLUSTER_LOCATION}" --format=json)
           CONTROL_PLANE_ALLOW_EXTERNAL_DNS=$(echo "${CLUSTER_INFO}" | jq -r '.controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic')
           if [ "${CONTROL_PLANE_ALLOW_EXTERNAL_DNS}" = "true" ]; then
             DNS_ENDPOINT_OPT="--dns-endpoint"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace CLOUDSDK_CORE_PROJECT with GCP_PROJECT in GKE cluster configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>010-configure-cluster</strong><dd><code>Update GCP project variable name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/docker-entrypoint.d/010-configure-cluster

<li>Changed the variable name from CLOUDSDK_CORE_PROJECT to GCP_PROJECT in <br>the gcloud command that describes the GKE cluster


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-cloud-tools/pull/48/files#diff-0f8693c02845e871e428f2788ecd4f88075a4f301fefcc05ff2f4cf3881334ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>