### PR TITLE
chore(deps): bump cloud-tools image and bundled CLIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN echo "Installing kubectl using the stable version of ${KUBECTL_STABLE_VERSIO
   chmod +x /usr/local/bin/kubectl
 
 # Download kubectx and kubens utilities
-# https://github.com/ah metb/kubectx
+# https://github.com/ahmetb/kubectx
 ENV KUBECTX_VERSION=0.11.0
 RUN curl -o /utility/kubens -sLO "https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_VERSION}/kubens" \
   && curl -o /utility/kubectx -sLO "https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_VERSION}/kubectx" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,8 @@ RUN curl -o /tmp/oniguruma-${ONIGURUMA_VERSION}.tar.gz -L "https://github.com/kk
 
 # Compile JQ
 RUN cd /tmp/jq-jq-${JQ_VERSION} \
-  && rm -rf modules/oniguruma \
-  && mkdir -p modules \
-  && mv /tmp/oniguruma-${ONIGURUMA_VERSION} /tmp/jq-jq-${JQ_VERSION}/modules/oniguruma \
+  && rm -rf vendor/oniguruma \
+  && mv /tmp/oniguruma-${ONIGURUMA_VERSION} /tmp/jq-jq-${JQ_VERSION}/vendor/oniguruma \
   && autoreconf -fi \
   && ./configure --with-oniguruma=builtin --disable-maintainer-mode \
   && make LDFLAGS=-all-static -j4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # AWS CLI v2
-ARG AWS_CLI_VERSION=2.25.6
+ARG AWS_CLI_VERSION=2.33.2
 ARG ALPINE_VERSION=3.20
 
 # To fetch the right alpine version use:
@@ -26,26 +26,26 @@ RUN apk --no-cache add autoconf automake build-base curl gzip libtool make opens
 
 # Download helm
 # https://github.com/helm/helm/releases
-ENV HELM_VERSION=3.17.3
+ENV HELM_VERSION=3.21.2
 RUN curl -o /tmp/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
   && tar -zxvf /tmp/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -C /tmp \
   && mv /tmp/linux-${TARGETARCH}/helm /usr/local/bin/helm
 
 # Download stern
 # https://github.com/stern/stern/releases
-ENV STERN_VERSION=1.32.0
+ENV STERN_VERSION=1.34.0
 RUN curl -o /tmp/stern_${STERN_VERSION}_linux_${TARGETARCH}.tar.gz -L "https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_${TARGETARCH}.tar.gz" \
   && tar -zxvf /tmp/stern_${STERN_VERSION}_linux_${TARGETARCH}.tar.gz -C /tmp \
   && mv /tmp/stern /usr/local/bin/stern
 
 # Download jq
 # https://github.com/jqlang/jq/releases
-ENV JQ_VERSION=1.7.1
-RUN curl -o /tmp/jq-${JQ_VERSION}.tar.gz -L "https://github.com/stedolan/jq/archive/refs/tags/jq-${JQ_VERSION}.tar.gz" \
+ENV JQ_VERSION=1.8.2
+RUN curl -o /tmp/jq-${JQ_VERSION}.tar.gz -L "https://github.com/jqlang/jq/archive/refs/tags/jq-${JQ_VERSION}.tar.gz" \
   && tar -zxvf /tmp/jq-${JQ_VERSION}.tar.gz -C /tmp
 
-# https://github.com/kkos/oniguruma/tree/v6.9.9
-ENV ONIGURUMA_VERSION=6.9.9
+# https://github.com/kkos/oniguruma/tree/v6.9.10
+ENV ONIGURUMA_VERSION=6.9.10
 RUN curl -o /tmp/oniguruma-${ONIGURUMA_VERSION}.tar.gz -L "https://github.com/kkos/oniguruma/archive/refs/tags/v${ONIGURUMA_VERSION}.tar.gz" \
   && tar -zxvf /tmp/oniguruma-${ONIGURUMA_VERSION}.tar.gz -C /tmp
 
@@ -91,15 +91,15 @@ RUN ln -s /usr/local/aws-cli/v2/current/bin/aws /usr/local/bin/aws \
   && ln -s /usr/local/aws-cli/v2/current/bin/aws_completer /usr/local/bin/aws_completer
 
 # Download kubectl
-# https://console.cloud.google.com/storage/browser/kubernetes-release/release
-ENV KUBECTL_STABLE_VERSION=1.31
+# https://kubernetes.io/releases/download/#binaries
+ENV KUBECTL_STABLE_VERSION=1.34
 RUN echo "Installing kubectl using the stable version of ${KUBECTL_STABLE_VERSION}..." && \
-  curl -so /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s "https://storage.googleapis.com/kubernetes-release/release/stable-${KUBECTL_STABLE_VERSION}.txt")/bin/linux/${TARGETARCH}/kubectl && \
+  curl -so /usr/local/bin/kubectl https://dl.k8s.io/release/$(curl -L -s "https://dl.k8s.io/release/stable-${KUBECTL_STABLE_VERSION}.txt")/bin/linux/${TARGETARCH}/kubectl && \
   chmod +x /usr/local/bin/kubectl
 
 # Download kubectx and kubens utilities
-# https://github.com/ahmetb/kubectx
-ENV KUBECTX_VERSION=0.9.5
+# https://github.com/ah metb/kubectx
+ENV KUBECTX_VERSION=0.11.0
 RUN curl -o /utility/kubens -sLO "https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_VERSION}/kubens" \
   && curl -o /utility/kubectx -sLO "https://github.com/ahmetb/kubectx/releases/download/v${KUBECTX_VERSION}/kubectx" \
   && chmod +x /utility/kubens /utility/kubectx \
@@ -110,7 +110,7 @@ RUN curl -o /utility/kubens -sLO "https://github.com/ahmetb/kubectx/releases/dow
 # Install Krew - kubectl plugin manager
 # https://github.com/kubernetes-sigs/krew/releases
 # https://krew.sigs.k8s.io/docs/user-guide/setup/install/
-ENV KREW_VERSION=0.4.5
+ENV KREW_VERSION=0.5.0
 RUN set -x; cd "$(mktemp -d)" \
   && OS="$(uname | tr '[:upper:]' '[:lower:]')" \
   && ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN curl -o /tmp/oniguruma-${ONIGURUMA_VERSION}.tar.gz -L "https://github.com/kk
 
 # Compile JQ
 RUN cd /tmp/jq-jq-${JQ_VERSION} \
-  && rmdir modules/oniguruma \
+  && rm -rf modules/oniguruma \
+  && mkdir -p modules \
   && mv /tmp/oniguruma-${ONIGURUMA_VERSION} /tmp/jq-jq-${JQ_VERSION}/modules/oniguruma \
   && autoreconf -fi \
   && ./configure --with-oniguruma=builtin --disable-maintainer-mode \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # You can find the list of the available image tags here:
 # https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/EU/google-cloud-cli
 
-GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 518.0.0-alpine
+GOOGLE_CLOUD_CLI_IMAGE_TAG ?= 573.0.0-alpine
 IMAGE_NAME ?= sparkfabrik/cloud-tools
 IMAGE_TAG ?= latest
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Monska85._

## What

This bumps the cloud-tools base image and the bundled CLI tooling to the latest available versions.

| Tool | From | To | Notes |
| --- | --- | --- | --- |
| google-cloud-cli | 518.0.0 | 573.0.0 | `Makefile` |
| aws-cli | 2.25.6 | 2.33.2 | latest tag for `alpine3.20` |
| helm | 3.17.3 | 3.21.2 | stays on the 3.x line; helm 4 is a breaking major |
| stern | 1.32.0 | 1.34.0 | |
| jq | 1.7.1 | 1.8.2 | source moved from `stedolan/jq` to `jqlang/jq` |
| oniguruma | 6.9.9 | 6.9.10 | jq build dependency |
| kubectl | 1.31 | 1.34 | also migrates the download URL (see below) |
| kubectx | 0.9.5 | 0.11.0 | |
| krew | 0.4.5 | 0.5.0 | |

## kubectl URL migration

kubectl was pinned to stable channel `1.31` and downloaded from `storage.googleapis.com/kubernetes-release`, which is frozen and caps at 1.31. The download now uses `dl.k8s.io`, the current endpoint, and the stable channel is bumped to `1.34` (it resolves to v1.34.9).

## Verification

All download URLs were verified to return HTTP 200 (helm, stern, jq, oniguruma, kubectx, krew, and the kubectl 1.34 binary).

## Notes

- helm is intentionally kept on the 3.x line per review. A separate PR can evaluate the helm 4 migration.
